### PR TITLE
Fixing the issue 5 where the .mm.dll files were breaking the testing

### DIFF
--- a/NuGet.PackageNPublish.NuGetPackage/Package/content/_MSBuild/NuGetPackageAndPublish.targets
+++ b/NuGet.PackageNPublish.NuGetPackage/Package/content/_MSBuild/NuGetPackageAndPublish.targets
@@ -111,8 +111,8 @@
     <!-- Copies the assemblies and symbol files we're packaging into the correct locations-->
     <Target Name="CopyAssembliesToLibDirectories">
       <ItemGroup>
-        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll" />
-        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb" />
+        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll;$(CopySourceFolder)\*.mm.dll" />
+        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb;$(CopySourceFolder)\*.mm.pdb" />
         <SL40Assemblies Include="$(CopySourceFolder)\*.Silverlight.dll" />
         <SL40Symbols Include="$(CopySourceFolder)\*.Silverlight.pdb" />
       </ItemGroup>

--- a/NuGet.PackageNPublish.NuGetPackage/_MSBuild/NuGetPackageAndPublish.targets
+++ b/NuGet.PackageNPublish.NuGetPackage/_MSBuild/NuGetPackageAndPublish.targets
@@ -111,8 +111,8 @@
     <!-- Copies the assemblies and symbol files we're packaging into the correct locations-->
     <Target Name="CopyAssembliesToLibDirectories">
       <ItemGroup>
-        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll" />
-        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb" />
+        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll;$(CopySourceFolder)\*.mm.dll" />
+        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb;$(CopySourceFolder)\*.mm.pdb" />
         <SL40Assemblies Include="$(CopySourceFolder)\*.Silverlight.dll" />
         <SL40Symbols Include="$(CopySourceFolder)\*.Silverlight.pdb" />
       </ItemGroup>

--- a/NuGet.PackageNPublish.ProjectTemplate/_MSBuild/NuGetPackageAndPublish.targets
+++ b/NuGet.PackageNPublish.ProjectTemplate/_MSBuild/NuGetPackageAndPublish.targets
@@ -111,8 +111,8 @@
     <!-- Copies the assemblies and symbol files we're packaging into the correct locations-->
     <Target Name="CopyAssembliesToLibDirectories">
       <ItemGroup>
-        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll" />
-        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb" />
+        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll;$(CopySourceFolder)\*.mm.dll" />
+        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb;$(CopySourceFolder)\*.mm.pdb" />
         <SL40Assemblies Include="$(CopySourceFolder)\*.Silverlight.dll" />
         <SL40Symbols Include="$(CopySourceFolder)\*.Silverlight.pdb" />
       </ItemGroup>

--- a/_MSBuild/NuGetPackageAndPublish.targets
+++ b/_MSBuild/NuGetPackageAndPublish.targets
@@ -100,8 +100,8 @@
     <!-- Copies the assemblies and symbol files we're packaging into the correct locations-->
     <Target Name="CopyAssembliesToLibDirectories">
       <ItemGroup>
-        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll" />
-        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb" />
+        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll;$(CopySourceFolder)\*.mm.dll" />
+        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb;$(CopySourceFolder)\*.mm.pdb" />
         <SL40Assemblies Include="$(CopySourceFolder)\*.Silverlight.dll" />
         <SL40Symbols Include="$(CopySourceFolder)\*.Silverlight.pdb" />
       </ItemGroup>


### PR DESCRIPTION
The following changes since commit 5c94dc2c122158980f244194818a91bc1fe5bc4a:

  Added link to getting started screencast (2012-11-14 12:30:01 +0000)

are available in the git repository at:

  https://github.com/JamesTryand/NuGet-PackageNPublish.git Issue-5-Hotfix

for you to fetch changes up to fe08cc4616fdb68eb6b7327aedb0a824f241afd9:

  Fixing the issue 5 where the .mm.dll files would be included in being copied to the bin folder and project output, thus causing autotest/mightymoose to go into a recursive loop and never finish testing. (2012-12-12 09:45:03 +0000)

---

James Tryand (1):
      Fixing the issue 5 where the .mm.dll files would be included in being copied to the bin folder and project output, thus causing autotest/mightymoose to go into a recursive loop and never finish testing.

 .../Package/content/_MSBuild/NuGetPackageAndPublish.targets           | 4 ++--
 .../_MSBuild/NuGetPackageAndPublish.targets                           | 4 ++--
 .../_MSBuild/NuGetPackageAndPublish.targets                           | 4 ++--
 _MSBuild/NuGetPackageAndPublish.targets                               | 4 ++--
 4 files changed, 8 insertions(+), 8 deletions(-)

The change was the same against all the targets and was : 
     <!-- Copies the assemblies and symbol files we're packaging into the correct locations-->
     <Target Name="CopyAssembliesToLibDirectories">
       <ItemGroup>
-        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll" />
-        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb" />
-        <Net40Assemblies Include="$(CopySourceFolder)\*.dll" Exclude="$(CopySourceFolder)\*.Silverlight.dll;$(CopySourceFolder)\*.Tests.dll;$(CopySourceFolder)\*.mm.dll" />
-        <Net40Symbols Include="$(CopySourceFolder)\*.pdb" Exclude="$(CopySourceFolder)\*.Silverlight.pdb;$(CopySourceFolder)\*.Tests.pdb;$(CopySourceFolder)\*.mm.pdb" />
       <SL40Assemblies Include="$(CopySourceFolder)\*.Silverlight.dll" />
       <SL40Symbols Include="$(CopySourceFolder)\*.Silverlight.pdb" />
     </ItemGroup>
