### PR TITLE
Fixed the path of common files in the localized version of the os

### DIFF
--- a/NuGet.PackageNPublish.NuGetPackage/Package/content/_MSBuild/NuGetPackageAndPublish.targets
+++ b/NuGet.PackageNPublish.NuGetPackage/Package/content/_MSBuild/NuGetPackageAndPublish.targets
@@ -17,8 +17,10 @@
     <PackagesConfig Condition="$(PackagesConfig) == '' Or $(PackagesConfig) == '*Undefined*'">$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
     <PackagesDir Condition="$(PackagesDir) == '' Or $(PackagesDir) == '*Undefined*'">$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
 
-    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(MSBuildExtensionsPath)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
-    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
     <TFPath Condition="$(TFPath) == '' Or $(NuGetToolsPathTFPath) == '*Undefined*'">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio 10.0\Common7\IDE\tf.exe</TFPath>
 
     <NuGetPackageName>$(ProjectDir)$(AssemblyName.Replace(".NuGetPackage", ""))</NuGetPackageName>

--- a/NuGet.PackageNPublish.NuGetPackage/_MSBuild/NuGetPackageAndPublish.targets
+++ b/NuGet.PackageNPublish.NuGetPackage/_MSBuild/NuGetPackageAndPublish.targets
@@ -17,8 +17,10 @@
     <PackagesConfig Condition="$(PackagesConfig) == '' Or $(PackagesConfig) == '*Undefined*'">$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
     <PackagesDir Condition="$(PackagesDir) == '' Or $(PackagesDir) == '*Undefined*'">$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
 
-    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(MSBuildExtensionsPath)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
-    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
     <TFPath Condition="$(TFPath) == '' Or $(NuGetToolsPathTFPath) == '*Undefined*'">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio 10.0\Common7\IDE\tf.exe</TFPath>
 
     <NuGetPackageName>$(ProjectDir)$(AssemblyName.Replace(".NuGetPackage", ""))</NuGetPackageName>

--- a/NuGet.PackageNPublish.ProjectTemplate/_MSBuild/NuGetPackageAndPublish.targets
+++ b/NuGet.PackageNPublish.ProjectTemplate/_MSBuild/NuGetPackageAndPublish.targets
@@ -17,8 +17,10 @@
     <PackagesConfig Condition="$(PackagesConfig) == '' Or $(PackagesConfig) == '*Undefined*'">$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
     <PackagesDir Condition="$(PackagesDir) == '' Or $(PackagesDir) == '*Undefined*'">$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
 
-    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(MSBuildExtensionsPath)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
-    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(MSBuildExtensionsPath32)\..\Common Files\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\11.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\11.0\TextTransform.exe</TTGenPath>
     <TFPath Condition="$(TFPath) == '' Or $(NuGetToolsPathTFPath) == '*Undefined*'">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio 10.0\Common7\IDE\tf.exe</TFPath>
 
     <NuGetPackageName>$(ProjectDir)$(AssemblyName.Replace(".NuGetPackage", ""))</NuGetPackageName>

--- a/_MSBuild/NuGetPackageAndPublish.targets
+++ b/_MSBuild/NuGetPackageAndPublish.targets
@@ -14,7 +14,8 @@
     <PackagesConfig Condition="$(PackagesConfig) == '' Or $(PackagesConfig) == '*Undefined*'">$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
     <PackagesDir Condition="$(PackagesDir) == '' Or $(PackagesDir) == '*Undefined*'">$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
 
-    <TTGenPath Condition="$(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*'">$(MSBuildExtensionsPath)\..\Common Files\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles(x86))\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
+    <TTGenPath Condition="($(TTGenPath) == '' Or $(TTGenPath) == '*Undefined*') And (Exists('$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe'))">$(CommonProgramFiles)\Microsoft Shared\TextTemplating\10.0\TextTransform.exe</TTGenPath>
     <TFPath Condition="$(TFPath) == '' Or $(NuGetToolsPathTFPath) == '*Undefined*'">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio 10.0\Common7\IDE\tf.exe</TFPath>
 
     <NuGetPackageName>$(ProjectDir)$(AssemblyName.Replace(".NuGetPackage", ""))</NuGetPackageName>


### PR DESCRIPTION
When use template in localized os version,it do not able locate TextTransform.exe.
